### PR TITLE
Should be xmlWriter.WriteDocType and not xmlWriter.WriteComment

### DIFF
--- a/PlistCS/Src/Plist.cs
+++ b/PlistCS/Src/Plist.cs
@@ -129,7 +129,8 @@ namespace PlistCS
                 using (XmlWriter xmlWriter = XmlWriter.Create(ms, xmlWriterSettings))
                 {
                     xmlWriter.WriteStartDocument(); 
-                    xmlWriter.WriteComment("DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" " + "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\"");
+                    //xmlWriter.WriteComment("DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" " + "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\"");
+                    xmlWriter.WriteDocType("plist", "-//Apple Computer//DTD PLIST 1.0//EN", "http://www.apple.com/DTDs/PropertyList-1.0.dtd", null);
                     xmlWriter.WriteStartElement("plist");
                     xmlWriter.WriteAttributeString("version", "1.0");
                     compose(value, xmlWriter);


### PR DESCRIPTION
Finally a good library to write and read plist files without resorting to unmanaged libraries. Congratulation for the great job!

I made a little correction to your code. Since the second line of a plist file is a document type declaration, you should use xmlWriter.WriteDocType instead of xmlWriter.WriteComment.
Using WriteDocType the generated output is exactly like an official Apple plist file, using WriteComment the generated output is a little different because there's an additional "--" after "<" and before ">". I'm not sure if this it is still fully conform to plist. All the others libraries seems to use WriteDocType method and therefore I deduce this is the way to go.

There's a few things that I need to understand. I noticed that reading a small plist file (25Kb), may require even a few seconds while with liplist (by JonathanBeck) it's instantaneous.
I'm not sure on what could be responsible of the delay, but maybe part of delay reside in the xml.Load method. When called I see that a TCP connection is established with akamai technologies servers. I don't know why this happen considering that the plist file reside locally, but I'm pretty sure that a TCP connection is really unneeded. Is there a way to block this connection without ending up in a System.Net.WebException or at least a way to make reading instant as liplist ?

Thanks
