### PR TITLE
remove unused variables (for suppressing warnings)

### DIFF
--- a/PlistCS/Src/Plist.cs
+++ b/PlistCS/Src/Plist.cs
@@ -723,8 +723,6 @@ namespace PlistCS
             List<int> refs = new List<int>();
             int refCount = 0;
 
-            byte dictByte = objectTable[offsetTable[objRef]];
-            
             int refStartPosition;
             refCount = getCount(offsetTable[objRef], out refStartPosition);
 
@@ -754,8 +752,6 @@ namespace PlistCS
             List<object> buffer = new List<object>();
             List<int> refs = new List<int>();
             int refCount = 0;
-
-            byte arrayByte = objectTable[offsetTable[objRef]];
 
             int refStartPosition;
             refCount = getCount(offsetTable[objRef], out refStartPosition);


### PR DESCRIPTION
`Plist.cs(726,18): warning CS0219: The variable `dictByte' is assigned but its value is never used`
`Plist.cs(758,18): warning CS0219: The variable `arrayByte' is assigned but its value is never used`
